### PR TITLE
Include all content on search index

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -99,7 +99,7 @@ eleventyConfig.setLibrary("md", markdownLibrary);
   eleventyConfig.addFilter("parseContent", (content) => {
     // Remove tags from content
     return (
-      striptags(content.substring(0, 500))
+      striptags(content)
         // Handle new lines
         .replaceAll(/(\r\n|\n|\r)/gm, " ")
         // Handle scaping


### PR DESCRIPTION
Fix #28 

Changes:

- Removed `substring` leftover for content parsing, all the content can be included on the search index without issues.

See:

![imagen](https://user-images.githubusercontent.com/44228131/212407139-baa9e0ae-0a3a-4240-b9b6-b3be691394b4.png)
