### PR TITLE
Add Pulsus to Android Enterprise zero-touch DPC extras collection

### DIFF
--- a/_src/android/android-enterprise-zero-touch-dpc-extras-collection.md
+++ b/_src/android/android-enterprise-zero-touch-dpc-extras-collection.md
@@ -260,6 +260,17 @@ Reach out to your vendor to ask when this functionality will be available.
 }
 </pre>
 
+## Pulsus
+
+<pre>
+{
+"android.app.extra.PROVISIONING_LEAVE_ALL_SYSTEM_APPS_ENABLED":<strong>true/false</strong>,
+"android.app.extra.PROVISIONING_ADMIN_EXTRAS_BUNDLE":{
+"pin":"<strong>groupPin</strong>"
+}
+}
+</pre>
+
 ## Google Workspace
 
 <pre>


### PR DESCRIPTION
This Change adds [Pulsus](https://pulsus.mobi/) EMM to Android Enterprise zero-touch DPC extras collection.

[Pulsus](https://pulsus.mobi/) is an [Android Enterprise Recommended Solution](https://androidenterprisepartners.withgoogle.com/provider/#!/5148960733790208) that supports Zero-touch.