### PR TITLE
Fix spinner removal in search debounce

### DIFF
--- a/_src/_includes/_assets/js/fuse-search.js
+++ b/_src/_includes/_assets/js/fuse-search.js
@@ -10,7 +10,7 @@ const debounce = (func) => {
   return function execute(...args) {
     // Empty search, remove spinner
     if (document.getElementById("searchField").value.trim() === "") {
-      deleteSpinner;
+      deleteSpinner();
       clearTimeout(timeout);
     } else if (!document.getElementById("debouncing")) {
       const searchResultsElement = document.getElementById("search-field");


### PR DESCRIPTION
## Summary
- call the deleteSpinner helper when the search field is cleared so the loading node is removed

## Testing
- npm run serve

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914cd83b62c832c927a065b15b78aac)