### PR TITLE
Fix search match index guard for zero-based matches

### DIFF
--- a/_src/_includes/_assets/js/fuse-search.js
+++ b/_src/_includes/_assets/js/fuse-search.js
@@ -182,7 +182,7 @@ document.addEventListener("DOMContentLoaded", async () => {
               new RegExp(`(${searchString})`, "gi").exec(value) ?? {};
             const matchIndex = exec.index;
 
-            if (matchIndex) {
+            if (matchIndex !== undefined && matchIndex !== null) {
               const wrapperLength = 100;
 
               const start = matchIndex - wrapperLength;


### PR DESCRIPTION
## Summary
- allow fuse search match handling to accept a zero index
- keep highlight rendering logic intact for first-word matches

## Testing
- node <<'NODE'
const value = 'Hello world this is test';
const searchString = 'Hello';
const exec = new RegExp(`(${searchString})`, 'gi').exec(value) ?? {};
const matchIndex = exec.index;
if (matchIndex !== undefined && matchIndex !== null) {
  const wrapperLength = 100;
  const start = matchIndex - wrapperLength;
  let highlightedContent;
  if (start < 0) {
    highlightedContent = value
      .substring(0, matchIndex + searchString.length + wrapperLength)
      .replace(new RegExp(`(${searchString})`, 'gi'), '<u><b>$1</b></u>') + '...';
  }
  console.log(highlightedContent);
} else {
  console.log('No match');
}
NODE

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691508dd042c832c999a77feb37ba545)